### PR TITLE
flash_mac.sh: allow spaces in directory name

### DIFF
--- a/flash/flash_mac.sh
+++ b/flash/flash_mac.sh
@@ -12,6 +12,6 @@ fi
 
 export "SPT_INSTALL_BIN=."
 
-$1/write_image_mac.sh
+"$1/write_image_mac.sh"
 
 blhost -u 0x15A2,0x0073 reset


### PR DESCRIPTION
I guess a PR is a bit overkill but I had the fix in my fork so…

Fixes https://github.com/expertsleepersltd/distingNT/issues/17
